### PR TITLE
Error: Could not set 'present' on ensure: can't convert Fixnum into String

### DIFF
--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -44,11 +44,21 @@ Puppet::Type.newtype(:sysctl) do
 
   newproperty(:val) do
     desc "An alias for 'value'. Maintains interface compatibility with the traditional ParsedFile sysctl provider. If both are set, 'value' will take precedence over 'val'."
+
+    munge do |val|
+      val.to_s
+    end
+
     include SysctlValueSync
   end
 
   newproperty(:value) do
     desc "Value to change the setting to. Settings with multiple values (such as net.ipv4.tcp_mem) are represented as a single whitespace separated string."
+
+    munge do |val|
+      val.to_s
+    end
+
     include SysctlValueSync
   end
 

--- a/spec/unit/puppet/type/sysctl_spec.rb
+++ b/spec/unit/puppet/type/sysctl_spec.rb
@@ -18,12 +18,22 @@ describe sysctl_type do
         resource = sysctl_type.new :name => 'foo', :val => 'foo'
         expect(resource[:val]).to eq('foo')
       end
+
+      it 'should be munged to a string' do
+        resource = sysctl_type.new :name => 'foo', :val => 42
+        expect(resource[:val]).to eq('42')
+      end
     end
 
     describe 'the value property' do
       it 'should be a valid property' do
         resource = sysctl_type.new :name => 'foo', :value => 'foo'
         expect(resource[:value]).to eq('foo')
+      end
+
+      it 'should be munged to a string' do
+        resource = sysctl_type.new :name => 'foo', :value => 42
+        expect(resource[:value]).to eq('42')
       end
     end
 


### PR DESCRIPTION
Running puppet 3.7.4 (from puppetlabs repo) on Ubuntu 14.04 - fully patched, and getting this error:

```
Error: /Stage[main]/Profile::Base/Sysctl[net.ipv6.conf.all.disable_ipv6]/ensure: change from absent to present failed: Could not set 'present' on ensure: can't convert Fixnum into String
Error: Could not set 'present' on ensure: can't convert Fixnum into String
Error: Could not set 'present' on ensure: can't convert Fixnum into String
Wrapped exception:
can't convert Fixnum into String
```

Manifest:
```
  # Manage sysctl as required by base profile
  Sysctl {
    ensure => 'present',
    apply  => true,
    target => "/etc/sysctl.d/99-sitelocal.conf",
  }
  $sysctl_base_hash = hiera_hash('sysctl_base',{})
  if is_hash($sysctl_base_hash) {
    create_resources(sysctl, $sysctl_base_hash)
  }
```
Hiera:
```
sysctl_base:
  net.ipv6.conf.all.disable_ipv6:
    value: 1
```

Ideas?