### PR TITLE
Added a :silent option to the sysctl type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ tmtags
 ## VIM
 *.swp
 tags
+.vagrant
+Gemfile.lock
+log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+- Added a :silent option for deliberately ignoring failures when applying the
+  live sysctl setting.
+- Added acceptance tests
+
 ## 2.0.2
 
 - Improve Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ end
 gem 'ruby-augeas', rbaugversion
 
 group :development, :unit_tests do
-  gem 'rake',                                              :require => false
+  gem 'rake',  '~> 10.0',                                  :require => false
   gem 'rspec', '< 3.2',                                    :require => false if RUBY_VERSION =~ /^1\.8/
   gem 'rspec-puppet',                                      :require => false
   gem 'puppetlabs_spec_helper',                            :require => false
@@ -38,8 +38,18 @@ group :development, :unit_tests do
   gem 'puppet-lint-version_comparison-check',              :require => false
   gem 'rspec-puppet-facts',                                :require => false
 
-  gem 'coveralls',                                         :require => false unless RUBY_VERSION =~ /^1\.8/
+  gem 'coveralls',                                         :require => false unless RUBY_VERSION =~ /^1\./
   gem 'simplecov', '~> 0.7.0',                             :require => false
   gem 'yard',                                              :require => false
   gem 'redcarpet', '~> 2.0',                               :require => false
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
+  gem 'simp-beaker-helpers'
 end

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Type documentation can be generated with `puppet doc -r type` or viewed on the
       apply  => false,
     }
 
+### ignore the application of a yet to be activated sysctl value
+
+    sysctl { "net.ipv6.conf.all.autoconf":
+      ensure => present,
+      value  => "1",
+      silent => true
+    }
 
 ## Issues
 

--- a/lib/puppet/provider/sysctl/augeas.rb
+++ b/lib/puppet/provider/sysctl/augeas.rb
@@ -16,11 +16,19 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
     "$target/#{resource[:name]}"
   end
 
-  def self.sysctl_set(key, value)
-    if Facter.value(:kernel) == :openbsd
-      sysctl("#{key}=#{value}")
-    else
-      sysctl('-w', %Q{#{key}=#{value}})
+  def self.sysctl_set(key, value, silent=false)
+    begin
+      if Facter.value(:kernel) == :openbsd
+        sysctl("#{key}=#{value}")
+      else
+        sysctl('-w', %Q{#{key}=#{value}})
+      end
+    rescue Puppet::ExecutionFailure => e
+      if silent
+        debug("augeasprovider_sysctl ignoring failed attempt to set #{key} due to :silent mode")
+      else
+        raise e
+      end
     end
   end
 
@@ -85,7 +93,12 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
   end
 
   def live_value
-    self.class.sysctl_get(resource[:name])
+    if resource[:silent] == :true
+      debug("augeasproviders_sysctl not setting live value for #{resource[:name]} due to :silent mode")
+      return resource[:value]
+    else
+      return self.class.sysctl_get(resource[:name])
+    end
   end
 
   attr_aug_accessor(:value, :label => :resource)
@@ -115,8 +128,9 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
   def flush
     super
     value = resource[:value] || resource[:val]
-    if resource[:apply] == :true and not value.nil?
-      self.class.sysctl_set(resource[:name], value)
+    if resource[:apply] == :true && !value.nil?
+      silent = (resource[:silent] == :true)
+      self.class.sysctl_set(resource[:name], value, silent)
     end
   end
 end

--- a/lib/puppet/provider/sysctl/augeas.rb
+++ b/lib/puppet/provider/sysctl/augeas.rb
@@ -95,7 +95,11 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
   def live_value
     if resource[:silent] == :true
       debug("augeasproviders_sysctl not setting live value for #{resource[:name]} due to :silent mode")
-      return resource[:value]
+      if resource[:value]
+        return resource[:value]
+      else
+        return resource[:val]
+      end
     else
       return self.class.sysctl_get(resource[:name])
     end

--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -74,7 +74,13 @@ Puppet::Type.newtype(:sysctl) do
   newparam(:apply, :boolean => true) do
     desc "Whether to apply the value using the sysctl command."
     newvalues(:true, :false)
-    defaultto(true)
+    defaultto(:true)
+  end
+
+  newparam(:silent, :boolean => true) do
+    desc "If set, do not report an error if the system key does not exist. This is useful for systems that may need to load a kernel module prior to the sysctl values existing."
+    newvalues(:true, :false)
+    defaultto(:false)
   end
 
   autorequire(:file) do

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "herculesteam-augeasproviders_sysctl",
-  "version": "2.0.2",
-  "author": "Dominic Cleal, Raphael Pinson",
+  "version": "2.1.0",
+  "author": "Dominic Cleal, Raphael Pinson, Trevor Vaughan",
   "summary": "Augeas-based sysctl type and provider for Puppet",
   "license": "Apache-2.0",
   "source": "https://github.com/hercules-team/augeasproviders_sysctl",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,32 @@
+HOSTS:
+  server:
+    roles:
+      - server
+      - default
+      - master
+    platform:   el-7-x86_64
+    box:        puppetlabs/centos-7.2-64-nocm
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.2-64-nocm
+    hypervisor: vagrant
+  centos-client:
+    roles:
+      - agent
+      - client
+    platform:   el-6-x86_64
+    box:        puppetlabs/centos-6.6-64-nocm
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+# Needs testing
+#  ubuntu-client:
+#    roles:
+#      - agent
+#      - client
+#    platform:   ubuntu-14.04-x86_64
+#    box:        puppetlabs/ubuntu-14.04-64-nocm
+#    box_url:    https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+#    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type:      foss
+  vagrant_memsize: 256
+  ## vb_gui: true

--- a/spec/acceptance/sysctl_spec.rb
+++ b/spec/acceptance/sysctl_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper_acceptance'
+
+test_name 'Augeasproviders Sysctl'
+
+describe 'Sysctl Tests' do
+  hosts.each do |host|
+    context 'file based updates' do
+      let(:manifest) {
+        <<-EOM
+          sysctl { 'fs.nr_open':
+            value => '100000',
+            apply => false
+          }
+        EOM
+      }
+
+      # Using puppet_apply as a helper
+      it 'should work with no errors' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest, {:catch_changes => true})
+      end
+
+      it 'should have applied successfuly in the sysctl config but not live' do
+        result = on(host, 'sysctl -n fs.nr_open').stdout.strip
+        expect(result).to_not eql('100000')
+
+        on(host, 'sysctl -p', :accept_all_exit_codes => true)
+        result = on(host, 'sysctl -n fs.nr_open').stdout.strip
+        expect(result).to eql('100000')
+      end
+    end
+
+    context 'full updates' do
+      let(:manifest) {
+        <<-EOM
+          sysctl { 'fs.nr_open':
+            value => '100001'
+          }
+        EOM
+      }
+
+      # Using puppet_apply as a helper
+      it 'should work with no errors' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest, {:catch_changes => true})
+      end
+
+      it 'should apply successfuly in the config and live' do
+        result = on(host, 'sysctl -n fs.nr_open').stdout.strip
+        expect(result).to eql('100001')
+      end
+
+      context 'when given an invalid key' do
+        let(:manifest) {
+          <<-EOM
+            sysctl { 'fs.this_cannot_exist':
+              value => 'I like bread'
+            }
+          EOM
+        }
+
+        it 'should fail to apply to the system' do
+          apply_manifest_on(host, manifest, :expect_failures => true)
+        end
+      end
+
+      context 'when silent' do
+        let(:manifest) {
+          <<-EOM
+            sysctl { 'fs.nr_open':
+              value  => '100002',
+              silent => true
+            }
+          EOM
+        }
+
+        # Using puppet_apply as a helper
+        it 'should work with no errors' do
+          apply_manifest_on(host, manifest, :catch_failures => true)
+        end
+  
+        it 'should be idempotent' do
+          apply_manifest_on(host, manifest, {:catch_changes => true})
+        end
+      end
+
+      context 'when silent and given a key that does not exist' do
+        let(:manifest) {
+          <<-EOM
+            sysctl { 'fs.this_cannot_exist':
+              value  => 'I like bread',
+              silent => true
+            }
+          EOM
+        }
+
+        # Using puppet_apply as a helper
+        it 'should work with no errors' do
+          apply_manifest_on(host, manifest, :catch_failures => true)
+        end
+  
+        it 'should be idempotent' do
+          apply_manifest_on(host, manifest, {:catch_changes => true})
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(dir, File.join(dir, 'fixtures/modules/augeasproviders_core/sp
 require 'rubygems'
 
 require 'simplecov'
-unless RUBY_VERSION =~ /^1\.8/
+unless RUBY_VERSION =~ /^1\./
   require 'coveralls'
   SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,34 @@
+require 'beaker-rspec'
+require 'tmpdir'
+require 'yaml'
+
+# Force FIPS off for these tests since it is not relevant.
+ENV['BEAKER_fips'] = 'no'
+
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Puppet
+    if host.is_pe?
+      install_pe
+    else
+      install_puppet
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include Helpers
+
+  # ensure that environment OS is ready on each host
+  fix_errata_on hosts
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  c.before :suite do
+    copy_fixture_modules_to( hosts )
+  end
+end


### PR DESCRIPTION
Some sysctl values do not get created until after a kernel module has
been loaded (NFS for example). As such, there are cases where you want
the sysctl provider to properly set up your system and change your
running value but you would like it to be silent if it cannot update the
live value.

Failures to update the file based configurations will still be an error
and silent failures will be added to the Puppet debug log.

Fixes hercules-team/augeasproviders_sysctl#6