### PR TITLE
Fix sysctl -a line parsing for FreeBSD

### DIFF
--- a/lib/puppet/provider/sysctl/augeas.rb
+++ b/lib/puppet/provider/sysctl/augeas.rb
@@ -78,10 +78,7 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
     resources ||= []
 
     sysctl('-a').each_line do |line|
-      value = line.split(/(=|:)/)
-
-      key = value.shift.strip
-      value = value.shift.to_s.strip
+      key, value = line.split(/\s?[=:]\s?/,2)
 
       existing_index = resources.index{ |x| x[:name] == key }
 

--- a/lib/puppet/provider/sysctl/augeas.rb
+++ b/lib/puppet/provider/sysctl/augeas.rb
@@ -78,11 +78,10 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
     resources ||= []
 
     sysctl('-a').each_line do |line|
-      value = line.split('=')
+      value = line.split(/(=|:)/)
 
       key = value.shift.strip
-
-      value = value.join('=').strip
+      value = value.shift.to_s.strip
 
       existing_index = resources.index{ |x| x[:name] == key }
 


### PR DESCRIPTION
Hello,

I ran in to a problem while using this nice module on FreeBSD.

Error: /Stage[main]/MyModule::Config/Sysctl[security.bsd.see_other_uids]: Could not evaluate: Error: `security.bsd.see_other_uids` is not a valid sysctl key
Error: /Stage[main]/MyModule::Config/Sysctl[security.bsd.see_other_gids]: Could not evaluate: Error: `security.bsd.see_other_gids` is not a valid sysctl key

These are valid keys for FreeBSD, so it shouldn't be giving the error. I tracked it down to https://github.com/hercules-team/augeasproviders_sysctl/blob/master/lib/puppet/provider/sysctl/augeas.rb#L81

`value = line.split('=')`

It's splitting each line of output from sysctl -a, looking for the equals sign, so it can extract the key and the value. The problem is that the output from Linux has an equals sign seperator, while the output from BSD has a colon ":" seperator. Since it can't match the key with the colon seperator it throws the error.

I fixed it by changing L81 to a RegExp `value = line.split(/(=|:)/)` that matches on either an equals sign, or a colon.

Thanks