### PR TITLE
Fix for FreeBSD

### DIFF
--- a/lib/puppet/provider/sysctl/augeas.rb
+++ b/lib/puppet/provider/sysctl/augeas.rb
@@ -77,7 +77,13 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
     # Grab everything else
     resources ||= []
 
-    sysctl('-a').each_line do |line|
+    sysctlArgs='-a'
+    # If we are on FreeBSD, provide -e which uses '=' instead of ':' to delimit values
+    if Facter.value(:kernel) == "FreeBSD"
+        sysctlArgs='-ae'
+    end
+
+    sysctl(sysctlArgs).each_line do |line|
       value = line.split('=')
 
       key = value.shift.strip


### PR DESCRIPTION
On FreeBSD sysctl -a separates OIDs and names with a colon, but the original authors were expecting an equals sign. Providing the -e switch to sysctl will output sysctl values in the expected output, allowing the existing code to parse the sysctl names correctly.