### PR TITLE
force data read from 'sysctl -a' into ASCSII

### DIFF
--- a/lib/puppet/provider/sysctl/augeas.rb
+++ b/lib/puppet/provider/sysctl/augeas.rb
@@ -83,6 +83,7 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
     end
 
     sysctl('-a').each_line do |line|
+      line = line.force_encoding("US-ASCII").scrub("")
       value = line.split(sep)
 
       key = value.shift.strip


### PR DESCRIPTION
Avoids Puppet complaining about invalid Unicode.  Bit of a hack, but gets around https://bugzilla.redhat.com/show_bug.cgi?id=1879868

