### PR TITLE
FreeBSD: skip read-only MIB data

### DIFF
--- a/lib/puppet/provider/sysctl/augeas.rb
+++ b/lib/puppet/provider/sysctl/augeas.rb
@@ -77,12 +77,14 @@ Puppet::Type.type(:sysctl).provide(:augeas, :parent => Puppet::Type.type(:augeas
     # Grab everything else
     resources ||= []
 
+    sysctl_all_args = '-a'
     sep = '='
+
     if Facter.value(:kernel) == 'FreeBSD'
-      sep = ':'
+      sysctl_all_args = '-aeW'
     end
 
-    sysctl('-a').each_line do |line|
+    sysctl(sysctl_all_args).each_line do |line|
       line = line.force_encoding("US-ASCII").scrub("")
       value = line.split(sep)
 


### PR DESCRIPTION
we will not handle read-only parameters, which are mostly statistics.
In some cases, this significantly reduces the modules operating time.
While Im here, lets get rid of the separate delimiter - FreeBSD allows
you to adjust this with an argument. Issue #47