### PR TITLE
Bump uppper limit of dep to augeasproviders_core

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders_core",
-      "version_requirement": ">=2.4.0 <3.0.0"
+      "version_requirement": ">=2.4.0 <4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This change makes module augeasproviders_sysctl compatible to version 3.x.y of module augeasproviders_core.

Fixes #56 